### PR TITLE
Refactor: Update deploy workflow to support release events and streamline artifact downloads

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -15,30 +15,28 @@ jobs:
   deploy-dev:
     name: Deploy to Dev
     runs-on: ubuntu-latest
-    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    if: (github.event_name == 'push' && github.ref == 'refs/heads/main') || github.event_name == 'release'
     environment: dev
     
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
 
-      - name: Setup Node.js
-        uses: actions/setup-node@v4
+      - name: Download API build artifacts
+        uses: dawidd6/action-download-artifact@v2
         with:
-          node-version: '20'
+          workflow: ci.yml
+          name: api-dist
+          path: api/dist/
+          branch: main
 
-      - name: Setup pnpm
-        uses: pnpm/action-setup@v2
+      - name: Download Web build artifacts
+        uses: dawidd6/action-download-artifact@v2
         with:
-          version: 8
-
-      - name: Install dependencies
-        run: pnpm install --frozen-lockfile
-
-      - name: Build
-        run: |
-          pnpm --filter api build
-          pnpm --filter web build
+          workflow: ci.yml
+          name: web-dist
+          path: web/dist/
+          branch: main
 
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v4
@@ -84,6 +82,7 @@ jobs:
     runs-on: ubuntu-latest
     if: github.event_name == 'release'
     environment: prod
+    needs: [deploy-dev]
     
     steps:
       - name: Checkout code
@@ -100,7 +99,7 @@ jobs:
           version: 8
 
       - name: Install dependencies
-        run: pnpm install --frozen-lockfile
+        run: pnpm install
 
       - name: Build
         run: |


### PR DESCRIPTION
This pull request updates the deployment workflow in `.github/workflows/deploy.yml` to improve efficiency and reliability. The main changes involve shifting build steps to a separate workflow and using build artifacts for deployment, as well as refining deployment triggers and dependencies.

**Workflow improvements:**

* The `deploy-dev` job now runs on both pushes to `main` and on `release` events, enabling deployments for both triggers.
* Instead of building the API and Web projects during deployment, the workflow now downloads pre-built artifacts from the `ci.yml` workflow, reducing deployment time and build redundancy.

**Deployment process changes:**

* The `deploy-prod` job now depends on the completion of `deploy-dev`, ensuring the dev deployment finishes before production deployment starts.
* The install step for dependencies in production no longer uses the frozen lockfile option, allowing for more flexibility in dependency resolution.