### PR TITLE
Refactor: Update CI workflow to ignore pushes to main branch

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,7 +4,7 @@ on:
   pull_request:
     branches: [main]
   push:
-    branches: [main]
+    branches-ignore: [main]
 
 permissions:
   id-token: write


### PR DESCRIPTION
This pull request makes a small configuration change to the CI workflow. The change updates the trigger for the workflow so that pushes to `main` are now ignored, rather than triggering the workflow.