### PR TITLE
Refactor: Remove pull request trigger for main branch in CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,8 +1,6 @@
 name: CI
 
 on:
-  pull_request:
-    branches: [main]
   push:
     branches-ignore: [main]
 


### PR DESCRIPTION
This pull request makes a small update to the GitHub Actions workflow configuration for CI. The change removes the trigger for running the workflow on pull requests to the `main` branch.