### PR TITLE
Refactor: Enhance CloudFront cache invalidation logic with error handling and logging

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -70,11 +70,19 @@ jobs:
         run: |
           DISTRIBUTION_ID=$(aws cloudfront list-distributions \
             --query "DistributionList.Items[?Origins.Items[0].DomainName=='${{ steps.stack-outputs.outputs.WEB_BUCKET }}.s3.amazonaws.com'].Id" \
-            --output text)
-          if [ ! -z "$DISTRIBUTION_ID" ]; then
-            aws cloudfront create-invalidation \
-              --distribution-id $DISTRIBUTION_ID \
-              --paths "/*"
+            --output text 2>/dev/null || echo "")
+          if [ ! -z "$DISTRIBUTION_ID" ] && [ "$DISTRIBUTION_ID" != "None" ]; then
+            echo "Found CloudFront distribution: $DISTRIBUTION_ID"
+            if aws cloudfront get-distribution --id "$DISTRIBUTION_ID" >/dev/null 2>&1; then
+              aws cloudfront create-invalidation \
+                --distribution-id $DISTRIBUTION_ID \
+                --paths "/*"
+              echo "CloudFront cache invalidated successfully"
+            else
+              echo "Distribution $DISTRIBUTION_ID does not exist or is not accessible"
+            fi
+          else
+            echo "No CloudFront distribution found for bucket ${{ steps.stack-outputs.outputs.WEB_BUCKET }}"
           fi
 
   deploy-prod:
@@ -138,9 +146,17 @@ jobs:
         run: |
           DISTRIBUTION_ID=$(aws cloudfront list-distributions \
             --query "DistributionList.Items[?Origins.Items[0].DomainName=='${{ steps.stack-outputs.outputs.WEB_BUCKET }}.s3.amazonaws.com'].Id" \
-            --output text)
-          if [ ! -z "$DISTRIBUTION_ID" ]; then
-            aws cloudfront create-invalidation \
-              --distribution-id $DISTRIBUTION_ID \
-              --paths "/*"
+            --output text 2>/dev/null || echo "")
+          if [ ! -z "$DISTRIBUTION_ID" ] && [ "$DISTRIBUTION_ID" != "None" ]; then
+            echo "Found CloudFront distribution: $DISTRIBUTION_ID"
+            if aws cloudfront get-distribution --id "$DISTRIBUTION_ID" >/dev/null 2>&1; then
+              aws cloudfront create-invalidation \
+                --distribution-id $DISTRIBUTION_ID \
+                --paths "/*"
+              echo "CloudFront cache invalidated successfully"
+            else
+              echo "Distribution $DISTRIBUTION_ID does not exist or is not accessible"
+            fi
+          else
+            echo "No CloudFront distribution found for bucket ${{ steps.stack-outputs.outputs.WEB_BUCKET }}"
           fi


### PR DESCRIPTION
This pull request improves the reliability and clarity of the CloudFront cache invalidation step in the deployment workflow. The main changes add better error handling and user feedback when attempting to invalidate the cache for a CloudFront distribution associated with the deployment bucket.

Enhancements to CloudFront cache invalidation:

* Added error handling to suppress unwanted error output when querying for the CloudFront distribution ID, and improved the conditional to check for both non-empty and non-"None" results. [[1]](diffhunk://#diff-28802fbf11c83a2eee09623fb192785e7ca92a3f40602a517c011b947a1822d3L73-R85) [[2]](diffhunk://#diff-28802fbf11c83a2eee09623fb192785e7ca92a3f40602a517c011b947a1822d3L141-R161)
* Added explicit feedback messages to indicate whether the CloudFront distribution was found, whether the cache invalidation succeeded, or if the distribution does not exist or is not accessible. [[1]](diffhunk://#diff-28802fbf11c83a2eee09623fb192785e7ca92a3f40602a517c011b947a1822d3L73-R85) [[2]](diffhunk://#diff-28802fbf11c83a2eee09623fb192785e7ca92a3f40602a517c011b947a1822d3L141-R161)