### PR TITLE
ci: use GitHub vars for VITE_LOCAL_DEV in deploy workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -51,7 +51,7 @@ jobs:
           pnpm build
         env:
           VITE_USE_MOCK_API: false
-          VITE_LOCAL_DEV: false
+          VITE_LOCAL_DEV: ${{ vars.VITE_LOCAL_DEV }}
           VITE_API_BASE_URL: ${{ vars.VITE_API_BASE_URL }}
           VITE_COGNITO_USER_POOL_ID: ${{ vars.VITE_COGNITO_USER_POOL_ID }}
           VITE_COGNITO_CLIENT_ID: ${{ vars.VITE_COGNITO_CLIENT_ID }}
@@ -150,7 +150,7 @@ jobs:
         run: pnpm --filter web build
         env:
           VITE_USE_MOCK_API: false
-          VITE_LOCAL_DEV: false
+          VITE_LOCAL_DEV: ${{ vars.VITE_LOCAL_DEV_PROD }}
           VITE_API_BASE_URL: ${{ vars.VITE_API_BASE_URL_PROD }}
           VITE_COGNITO_USER_POOL_ID: ${{ vars.VITE_COGNITO_USER_POOL_ID_PROD }}
           VITE_COGNITO_CLIENT_ID: ${{ vars.VITE_COGNITO_CLIENT_ID_PROD }}


### PR DESCRIPTION
This pull request updates environment variable handling in the deployment workflow configuration to use GitHub Actions variables for greater flexibility and control.

Environment variable management improvements:

* [`.github/workflows/deploy.yml`](diffhunk://#diff-28802fbf11c83a2eee09623fb192785e7ca92a3f40602a517c011b947a1822d3L54-R54): Changed `VITE_LOCAL_DEV` assignment to use `${{ vars.VITE_LOCAL_DEV }}` instead of a hardcoded value, allowing dynamic configuration from repository or organization-level variables.
* [`.github/workflows/deploy.yml`](diffhunk://#diff-28802fbf11c83a2eee09623fb192785e7ca92a3f40602a517c011b947a1822d3L153-R153): Updated the production build step to use `${{ vars.VITE_LOCAL_DEV_PROD }}` for `VITE_LOCAL_DEV`, enabling separate configuration for production deployments.