### PR TITLE
feat: add demo credentials to LoginPage; remove dev-only Recent Activity card from DashboardPage

### DIFF
--- a/web/src/pages/DashboardPage.tsx
+++ b/web/src/pages/DashboardPage.tsx
@@ -87,17 +87,6 @@ export default function DashboardPage() {
               </p>
             </div>
           </div>
-
-          <div className="bg-white dark:bg-gray-800 p-6 rounded-lg shadow">
-            <h3 className="text-lg font-semibold text-gray-900 dark:text-white mb-4">Recent Activity</h3>
-            <p className="text-gray-600 dark:text-gray-300">Load management system is ready for development!</p>
-            <p className="text-sm text-gray-500 dark:text-gray-400 mt-2">
-              API Server: <span className="text-green-600 dark:text-green-400">Running on localhost:3001</span>
-            </p>
-            <p className="text-sm text-gray-500 dark:text-gray-400">
-              Database: <span className="text-green-600 dark:text-green-400">Connected to local DynamoDB</span>
-            </p>
-          </div>
         </div>
       </main>
     </div>

--- a/web/src/pages/LoginPage.tsx
+++ b/web/src/pages/LoginPage.tsx
@@ -2,6 +2,12 @@ import { useState } from 'react';
 import { useAuth } from '../hooks/useAuth';
 import { DarkModeToggle } from '../components/DarkModeToggle';
 
+const DEMO_CREDENTIALS = [
+  { role: 'Admin', email: 'admin@couriertest.com', password: 'Admin123!' },
+  { role: 'Co-Admin', email: 'coadmin@couriertest.com', password: 'Coadmin123!' },
+  { role: 'Driver', email: 'driver@couriertest.com', password: 'Driver123!' },
+];
+
 export default function LoginPage() {
   const { login } = useAuth();
   const [error, setError] = useState('');
@@ -63,8 +69,50 @@ export default function LoginPage() {
             </button>
           </div>
 
-          <div className="mt-6 text-xs text-gray-500 text-center">
+          <div className="mt-6 text-xs text-gray-500 dark:text-gray-400 text-center">
             You will be redirected to AWS Cognito for secure authentication
+          </div>
+
+          <div className="mt-8 border-t border-gray-200 dark:border-gray-700 pt-6">
+            <h3 className="text-sm font-medium text-gray-900 dark:text-white mb-4 text-center">
+              Demo Credentials
+            </h3>
+            <div className="space-y-3">
+              {DEMO_CREDENTIALS.map((cred, index) => (
+                <div key={index} className="bg-gray-50 dark:bg-gray-700 p-3 rounded-md">
+                  <div className="text-xs font-semibold text-gray-700 dark:text-gray-300 mb-2">
+                    {cred.role}
+                  </div>
+                  <div className="space-y-1">
+                    <div className="flex items-center justify-between">
+                      <span className="text-xs text-gray-600 dark:text-gray-400">Email:</span>
+                      <button
+                        onClick={() => {
+                          navigator.clipboard.writeText(cred.email);
+                        }}
+                        className="text-xs text-indigo-600 dark:text-indigo-400 hover:text-indigo-800 dark:hover:text-indigo-300 font-mono"
+                      >
+                        {cred.email} 📋
+                      </button>
+                    </div>
+                    <div className="flex items-center justify-between">
+                      <span className="text-xs text-gray-600 dark:text-gray-400">Password:</span>
+                      <button
+                        onClick={() => {
+                          navigator.clipboard.writeText(cred.password);
+                        }}
+                        className="text-xs text-indigo-600 dark:text-indigo-400 hover:text-indigo-800 dark:hover:text-indigo-300 font-mono"
+                      >
+                        {cred.password} 📋
+                      </button>
+                    </div>
+                  </div>
+                </div>
+              ))}
+            </div>
+            <p className="text-xs text-gray-500 dark:text-gray-400 text-center mt-4">
+              Click on credentials to copy them
+            </p>
           </div>
         </div>
       </div>


### PR DESCRIPTION
This pull request updates the login experience by adding demo credentials to the `LoginPage` for easier testing and removes the "Recent Activity" section from the `DashboardPage`. The most important changes are grouped below:

**Login page improvements:**

* Added a `DEMO_CREDENTIALS` constant to `LoginPage.tsx` containing sample credentials for Admin, Co-Admin, and Driver roles.
* Displayed demo credentials with copy-to-clipboard buttons for each email and password, and included a note explaining the feature.

**Dashboard page cleanup:**

* Removed the "Recent Activity" card from `DashboardPage.tsx`, simplifying the dashboard layout.