### PR TITLE
fix(auth): use id_token for storage/restore and clear on expiry

### DIFF
--- a/web/src/hooks/useAuth.tsx
+++ b/web/src/hooks/useAuth.tsx
@@ -57,7 +57,7 @@ const AuthContext = createContext<AuthContextType | undefined>(undefined);
 const initToken = () => {
   if (typeof window !== 'undefined' && import.meta.env.VITE_LOCAL_DEV !== 'true') {
     try {
-      const storedToken = localStorage.getItem('access_token');
+      const storedToken = localStorage.getItem('id_token');
       if (storedToken) {
         // Set token immediately so it's available for API calls
         setAuthToken(storedToken);
@@ -100,7 +100,7 @@ export function AuthProvider({ children }: { children: ReactNode }) {
 
       // Try to restore token from localStorage
       try {
-        const storedToken = localStorage.getItem('access_token');
+        const storedToken = localStorage.getItem('id_token');
         if (storedToken) {
           console.log('[AUTH DEBUG] Restoring token from localStorage');
           setAuthToken(storedToken);
@@ -113,6 +113,7 @@ export function AuthProvider({ children }: { children: ReactNode }) {
             // Check if token is expired
             if (tokenPayload.exp && tokenPayload.exp * 1000 < Date.now()) {
               console.log('[AUTH DEBUG] Token expired, clearing');
+              localStorage.removeItem('id_token');
               localStorage.removeItem('access_token');
               localStorage.removeItem('refresh_token');
               setUser(null);
@@ -131,6 +132,7 @@ export function AuthProvider({ children }: { children: ReactNode }) {
             return;
           } catch (decodeError) {
             console.error('[AUTH DEBUG] Failed to decode stored token:', decodeError);
+            localStorage.removeItem('id_token');
             localStorage.removeItem('access_token');
           }
         }
@@ -202,6 +204,7 @@ export function AuthProvider({ children }: { children: ReactNode }) {
     
     // Clear stored tokens
     try {
+      localStorage.removeItem('id_token');
       localStorage.removeItem('access_token');
       localStorage.removeItem('refresh_token');
       localStorage.removeItem('currentUser');
@@ -294,8 +297,8 @@ export function AuthProvider({ children }: { children: ReactNode }) {
         
         // Persist tokens to localStorage
         try {
-          localStorage.setItem('access_token', tokens.access_token);
           localStorage.setItem('id_token', tokens.id_token);
+          localStorage.setItem('access_token', tokens.access_token);
           if (tokens.refresh_token) {
             localStorage.setItem('refresh_token', tokens.refresh_token);
           }


### PR DESCRIPTION
This pull request updates the authentication token management in `web/src/hooks/useAuth.tsx` to consistently use `id_token` instead of `access_token` when restoring and clearing tokens from localStorage. It also ensures that both `id_token` and `access_token` are properly handled in all relevant authentication flows.

**Authentication token management improvements:**

* Changed token restoration logic to use `id_token` instead of `access_token` when initializing and restoring the authentication state from localStorage. [[1]](diffhunk://#diff-70636c3c81fabbb81aaadc0eb60587b5cbacd2ed88007409f2ead6d653ad935aL60-R60) [[2]](diffhunk://#diff-70636c3c81fabbb81aaadc0eb60587b5cbacd2ed88007409f2ead6d653ad935aL103-R103)
* Added removal of `id_token` from localStorage when the token is expired or fails to decode, ensuring both `id_token` and `access_token` are cleared on logout and error. [[1]](diffhunk://#diff-70636c3c81fabbb81aaadc0eb60587b5cbacd2ed88007409f2ead6d653ad935aR116) [[2]](diffhunk://#diff-70636c3c81fabbb81aaadc0eb60587b5cbacd2ed88007409f2ead6d653ad935aR135) [[3]](diffhunk://#diff-70636c3c81fabbb81aaadc0eb60587b5cbacd2ed88007409f2ead6d653ad935aR207)
* Updated token persistence logic to store both `id_token` and `access_token` in localStorage after successful authentication.