### PR TITLE
Fix: Use ID token instead of access token for authentication

### DIFF
--- a/api/src/functions/org/get-settings.ts
+++ b/api/src/functions/org/get-settings.ts
@@ -21,11 +21,60 @@ export const handler = async (event: APIGatewayProxyEventV2): Promise<APIGateway
       };
     }
 
+    // Transform DynamoDB structure to frontend format
+    const settings = org.settings || {};
+    const company = settings.company || {};
+    const operations = settings.operations || {};
+    const notifications = settings.notifications || {};
+    const defaultLoadSettings = operations.defaultLoadSettings || {};
+    
+    const transformedSettings = {
+      companyName: company.name || '',
+      companyAddress: company.address || {
+        street: '',
+        city: '',
+        state: '',
+        zip: '',
+        country: '',
+      },
+      companyPhone: company.phone || '',
+      companyEmail: company.email || '',
+      website: company.website || '',
+      operatingHours: operations.operatingHours || {
+        start: '09:00',
+        end: '17:00',
+        timezone: 'America/Chicago',
+      },
+      deliveryRadius: operations.deliveryRadius || 50,
+      emailNotifications: notifications.emailNotifications || {
+        loadCreated: true,
+        loadAssigned: true,
+        loadCompleted: true,
+        driverCheckedIn: false,
+        urgentAlerts: true,
+      },
+      smsNotifications: notifications.smsNotifications || {
+        loadAssigned: false,
+        loadCompleted: false,
+        urgentAlerts: false,
+      },
+      autoAssignLoads: defaultLoadSettings.autoAssign || false,
+      requireSignature: defaultLoadSettings.requireSignature || true,
+      allowPartialDeliveries: defaultLoadSettings.allowPartialDeliveries || false,
+      maxLoadsPerDriver: defaultLoadSettings.maxLoadsPerDriver || 10,
+      defaultHourlyRate: operations.defaultHourlyRate || 25,
+      mileageRate: operations.mileageRate || 0.65,
+      currency: operations.currency || 'USD',
+      gpsTracking: operations.gpsTracking || true,
+      routeOptimization: operations.routeOptimization || false,
+      customFields: settings.customFields || [],
+    };
+
     logRequest(authContext, 'GET_ORG_SETTINGS', { status: 'success' });
 
     return {
       statusCode: 200,
-      body: JSON.stringify(org),
+      body: JSON.stringify({ settings: transformedSettings }),
     };
   } catch (error: any) {
     console.error('Error getting org settings:', error);

--- a/docker/seed-production-data.sh
+++ b/docker/seed-production-data.sh
@@ -13,6 +13,61 @@ DRIVER4_ID="driver-emily-rodriguez"
 
 echo "Seeding production data to $TABLE_NAME..."
 
+# Create Organization Settings
+echo "Creating organization settings..."
+aws dynamodb put-item \
+  --table-name $TABLE_NAME \
+  --item '{
+    "PK": {"S": "ORG#'$ORG_ID'"},
+    "SK": {"S": "ORG#'$ORG_ID'"},
+    "orgId": {"S": "'$ORG_ID'"},
+    "settings": {"M": {
+      "company": {"M": {
+        "name": {"S": "Courier Test Org"},
+        "email": {"S": "info@couriertest.com"},
+        "phone": {"S": "(555) 123-4567"},
+        "website": {"S": "https://couriertest.com"},
+        "address": {"M": {
+          "street": {"S": "1234 Business Ave"},
+          "city": {"S": "Houston"},
+          "state": {"S": "TX"},
+          "zip": {"S": "77001"},
+          "country": {"S": "USA"}
+        }}
+      }},
+      "operations": {"M": {
+        "operatingHours": {"M": {
+          "monday": {"M": {"start": {"S": "08:00"}, "end": {"S": "17:00"}, "enabled": {"BOOL": true}}},
+          "tuesday": {"M": {"start": {"S": "08:00"}, "end": {"S": "17:00"}, "enabled": {"BOOL": true}}},
+          "wednesday": {"M": {"start": {"S": "08:00"}, "end": {"S": "17:00"}, "enabled": {"BOOL": true}}},
+          "thursday": {"M": {"start": {"S": "08:00"}, "end": {"S": "17:00"}, "enabled": {"BOOL": true}}},
+          "friday": {"M": {"start": {"S": "08:00"}, "end": {"S": "17:00"}, "enabled": {"BOOL": true}}},
+          "saturday": {"M": {"start": {"S": "09:00"}, "end": {"S": "13:00"}, "enabled": {"BOOL": false}}},
+          "sunday": {"M": {"start": {"S": "09:00"}, "end": {"S": "13:00"}, "enabled": {"BOOL": false}}}
+        }},
+        "defaultLoadSettings": {"M": {
+          "autoAssign": {"BOOL": false},
+          "requireSignature": {"BOOL": true},
+          "allowDriverNotes": {"BOOL": true}
+        }}
+      }},
+      "notifications": {"M": {
+        "emailNotifications": {"M": {
+          "loadAssigned": {"BOOL": true},
+          "loadCompleted": {"BOOL": true},
+          "loadCancelled": {"BOOL": true},
+          "dailyDigest": {"BOOL": false}
+        }},
+        "smsNotifications": {"M": {
+          "enabled": {"BOOL": false}
+        }}
+      }}
+    }},
+    "createdAt": {"S": "2025-10-20T08:00:00Z"},
+    "updatedAt": {"S": "2025-10-20T08:00:00Z"}
+  }' \
+  --region $REGION
+
 # Create Driver Users
 echo "Creating driver users..."
 


### PR DESCRIPTION
This pull request introduces a standardized transformation layer between the frontend and backend for organization settings, ensuring consistent data formats and improving maintainability. The changes also seed production data with a sample organization settings record for testing and onboarding purposes.

**Backend/frontend data transformation:**

* Added logic in `api/src/functions/org/get-settings.ts` to transform the raw DynamoDB organization settings structure into a frontend-friendly format before returning it in API responses.
* Updated `api/src/functions/org/update-settings.ts` to convert incoming frontend settings into the DynamoDB schema before saving, ensuring the backend stores data in a consistent format.

**Production data seeding:**

* Added a new step in `docker/seed-production-data.sh` to seed the database with a sample organization settings record, including company info, operations, and notifications, for easier testing and onboarding.